### PR TITLE
Added pytest-mock to get mocker in tests working

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ lint =
 	yapf >= 0.30.0
 test =
 	pytest >= 6.2.4
+	pytest-mock
 all =
 	%(doc)s
 	%(lint)s


### PR DESCRIPTION
The tests don't run properly unless `pytest-mock` is there for the `mocker` calls. Here's my call to `pip freeze` for posterity:

```
airtigrs==0.0.0
alabaster==0.7.12
alembic==1.7.4
anyio==3.3.4
apache-airflow==2.2.1
apache-airflow-providers-ftp==2.0.1
apache-airflow-providers-http==2.0.1
apache-airflow-providers-imap==2.0.1
apache-airflow-providers-sftp==2.2.0
apache-airflow-providers-sqlite==2.0.1
apache-airflow-providers-ssh==2.3.0
apispec==3.3.2
argcomplete==1.12.3
attrs==21.2.0
Babel==2.9.1
bcrypt==3.2.0
bids-validator==1.8.4
blinker==1.4
cached-property==1.5.2
cattrs==1.6.0
certifi==2021.10.8
cffi==1.15.0
chardet==3.0.4
charset-normalizer==2.0.7
click==7.1.2
clickclick==20.10.2
colorama==0.4.4
colorlog==5.0.1
commonmark==0.9.1
croniter==1.0.15
cryptography==35.0.0
cycler==0.11.0
datman==0.2.0rc1+391.ga0cd1ff.dirty
defusedxml==0.7.1
dill==0.3.4
dnspython==2.1.0
docopt==0.6.2
docutils==0.16
email-validator==1.1.3
flake8==4.0.1
Flask==1.1.4
Flask-AppBuilder==3.3.4
Flask-Babel==2.0.0
Flask-Caching==1.10.1
Flask-JWT-Extended==3.25.1
Flask-Login==0.4.1
Flask-OpenID==1.3.0
Flask-SQLAlchemy==2.5.1
Flask-WTF==0.14.3
graphviz==0.17
greenlet==1.1.2
gunicorn==20.1.0
h11==0.12.0
httpcore==0.13.7
httpx==0.20.0
idna==2.8
imagesize==1.2.0
importlib-metadata==4.8.1
importlib-resources==5.4.0
inflection==0.5.1
iniconfig==1.1.1
iso8601==0.1.16
isodate==0.6.0
itsdangerous==1.1.0
Jinja2==3.0.2
joblib==1.1.0
jsonschema==3.2.0
kiwisolver==1.3.2
lazy-object-proxy==1.6.0
lockfile==0.12.2
lxml==4.6.4
Mako==1.1.5
Markdown==3.3.4
MarkupSafe==1.1.1
marshmallow==3.14.0
marshmallow-enum==1.5.1
marshmallow-oneofschema==3.0.1
marshmallow-sqlalchemy==0.26.1
matplotlib==3.1.3
mccabe==0.6.1
nibabel==3.0.2
nilearn==0.7.1
num2words==0.5.10
numpy==1.18.5
openapi-schema-validator==0.1.5
openapi-spec-validator==0.3.1
packaging==21.2
pandas==1.0.5
paramiko==2.8.0
patsy==0.5.2
pendulum==2.1.2
pluggy==1.0.0
prison==0.2.1
psutil==5.8.0
py==1.11.0
pybids==0.10.2
pycodestyle==2.8.0
pycparser==2.20
pydicom==1.3.0
pyflakes==2.4.0
Pygments==2.10.0
PyJWT==1.7.1
PyNaCl==1.4.0
pyparsing==2.4.7
pyrsistent==0.18.0
pysftp==0.2.9
pytest==6.2.5
pytest-mock==3.6.1
python-daemon==2.3.0
python-dateutil==2.8.2
python-nvd3==0.15.0
python-slugify==4.0.1
python3-openid==3.2.0
pytz==2021.3
pytzdata==2020.1
pyxnat==1.2.1.0.post3
PyYAML==5.4.1
requests==2.22.0
rfc3986==1.5.0
rich==10.12.0
scikit-learn==1.0.1
scipy==1.7.1
setproctitle==1.2.2
six==1.16.0
sniffio==1.2.0
snowballstemmer==2.1.0
Sphinx==4.2.0
sphinx-autodoc-typehints==1.12.0
sphinx-multiversion==0.2.4
sphinx-rtd-theme==1.0.0
sphinxcontrib-applehelp==1.0.2
sphinxcontrib-devhelp==1.0.2
sphinxcontrib-htmlhelp==2.0.0
sphinxcontrib-jsmath==1.0.1
sphinxcontrib-qthelp==1.0.3
sphinxcontrib-serializinghtml==1.1.5
SQLAlchemy==1.4.26
SQLAlchemy-JSONField==1.0.0
SQLAlchemy-Utils==0.37.9
sshtunnel==0.4.0
swagger-ui-bundle==0.0.9
tabulate==0.8.9
tenacity==8.0.1
termcolor==1.1.0
text-unidecode==1.3
threadpoolctl==3.0.0
toml==0.10.2
typing-extensions==3.10.0.2
unicodecsv==0.14.1
urllib3==1.25.11
Werkzeug==1.0.1
wrapt==1.11.2
WTForms==2.3.3
yapf==0.31.0
zipp==3.6.0

```