### PR TITLE
Initial offering of DAG factory for task parsers

### DIFF
--- a/dags/generate_task_parser_dags.py
+++ b/dags/generate_task_parser_dags.py
@@ -1,0 +1,62 @@
+from datetime import timedelta, datetime
+import logging
+
+from airflow import DAG
+from airflow.operators.bash import BashOperator
+
+import datman.config
+from datman.exceptions import UndefinedSetting
+
+
+default_args = {
+        'owner': 'bselby',
+        'depends_on_past': False,
+        }
+
+
+def make_task_parser_dag(dag_id, study, config, parser, default_args):
+    '''
+    Creates a task parser dag for a given study.
+
+    Returns a DAG composed of a BashOperator which simply calls the parser
+    specified in the study config.
+    '''
+
+    dag = DAG(
+            f'parse_tasks_{study}',
+            default_args=default_args,
+            description='Generates .tsvs from task data',
+            schedule_interval=timedelta(days=1),
+            start_date=datetime(2021, 1, 1),
+            catchup=False,
+            tags=['datman'])
+
+    with dag:
+        for task in parser.keys():
+            parse_task = BashOperator(
+                task_id=f'parse_{task}_task',
+                bash_command='{{params.command}}',
+                params={"command": parser[task]})
+
+    return dag
+
+
+config = datman.config.config()
+projects = config.get_key("Projects")
+logging.basicConfig(filename='task_parser_dags.log',
+                    encoding='utf-8',
+                    level=logging.DEBUG)
+
+for proj in projects:
+    try:
+        config.set_study(proj)
+        parser = config.get_key('TaskParser')
+        dag_id = f"{config.study_name}_task_parser"
+        logging.info(f"Task parser {parser} specified for {proj}")
+        dag = make_task_parser_dag(dag_id, proj, config, parser, default_args)
+        if dag is not None:
+            globals()[dag_id] = dag
+ 
+    except UndefinedSetting:
+        continue
+


### PR DESCRIPTION
This is an example of how the DAG factory pattern can be used for task parsers. Right now it's quite simplistic: a `TaskParser ` key is added to the study's `settings.yml`, which lists tasks and the appropriate command. As of now this means it does not support any dynamic arguments to whatever command is being issued - we can discuss if this is an important feature or not. 

So for example, `SPN20_settings.yml` needs to contain the additional key:

```
TaskParser:
    EA: dm_parse_ea.py SPN20 --debug --regex "*MR*EMP*"
```

Studies can specify multiple task parsers, e.g. for OPT:
```
TaskParser:
        FACES: dm_parse_faces.py OPT
        FAKE: echo "FAKE OUT!"
```

I still need to write tests for this implementation but thought I would post for feedback beforehand since it's been a long time coming!