### PR TITLE
DOCS: Initial configuration setup for API docs

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,3 +25,6 @@ sphinx:
     - 'sphinx.ext.autodoc'
     - 'sphinx.ext.napoleon'
     - 'sphinx.ext.viewcode'
+    - 'sphinx.ext.autosummary'
+  config:
+    autosummary_generate: True

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -18,3 +18,10 @@ repository:
   url: https://github.com/tigrlab/air-tigrs
   path_to_book: docs
   branch: main
+
+# Set sphinx extensions for build
+sphinx:
+  extra_extensions:
+    - 'sphinx.ext.autodoc'
+    - 'sphinx.ext.napoleon'
+    - 'sphinx.ext.viewcode'

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,6 +1,6 @@
-# Table of contents
-# Learn more at https://jupyterbook.org/customize/toc.html
-
-- file: index
+format: jb-article
+root: index
+sections:
 - file: contributing
 - file: security
+- file: modules

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,0 +1,9 @@
+API Reference
+=============
+
+.. autosummary::
+   :toctree: _autosummary
+   :recursive:
+
+   airtigrs.operators
+   airtigrs.utils


### PR DESCRIPTION
Will need to integrate this into CI after #22 

Prior to Jupyter-Book deployment we'll just have to run `sphinx-apidoc -o ./docs airtigrs/ '*test*'` to generate the `.rst` files. These will then be deployed alongside the user-guides/notes in the  `jb build` step